### PR TITLE
Add 74X codes for the "Meme Driven" section ...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,9 @@ We humbly suggest the following status codes are included in the HTTP spec in th
     - 735 - Fucking IE
     - 736 - Fucking Race Conditions
     - 737 - FuckThreadsing
+  * 74X - Meme Driven
+    - 741 - Compiling
+    - 742 - A kitten dies
   * 76X - Substance-Affected Developer
     - 761 - Hungover
     - 762 - Stoned


### PR DESCRIPTION
Adding 74X codes a "Meme Driven" section with two codes: 741 and 742.

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
