### PR TITLE
Status 747, errors due to excess Squamata - often seen in Samuel-ation runs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ We humbly suggest the following status codes are included in the HTTP spec in th
   * 74X - Meme Driven
     - 741 - Compiling
     - 742 - A kitten dies
+    - 747 - Motherfucking Snakes on the Motherfucking Plane
   * 76X - Substance-Affected Developer
     - 761 - Hungover
     - 762 - Stoned


### PR DESCRIPTION
747 - Motherfucking Snakes on the Motherfucking Plane
