### PR TITLE
More memes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ We humbly suggest the following status codes are included in the HTTP spec in th
   * 74X - Meme Driven
     - 741 - Compiling
     - 742 - A kitten dies
+    - 743 - I thought I knew regular expressions
     - 746 - Missed Ballmer Peak
   * 76X - Substance-Affected Developer
     - 761 - Hungover


### PR DESCRIPTION
add codes for missing Ballmer Peak (Ballmer's Peak?) and thinking you know regexes.
