### PR TITLE
751 - Herp Derp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ We humbly suggest the following status codes are included in the HTTP spec in th
     - 749 - Reserved for Chuck Norris 
   * 75X - Syntax Errors
     - 750 - Didn't bother to compile it
+    - 751 - Herp Derp
     - 753 - Syntax Error
     - 759 - Unexpected T_PAAMAYIM_NEKUDOTAYIM
   * 76X - Substance-Affected Developer


### PR DESCRIPTION
Add "herp derp" list of syntax error status codes as code 751.