### PR TITLE
Fix missing Unicode in HTTP 738

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ We humbly suggest the following status codes are included in the HTTP spec in th
     - 727 - 32 bits is plenty
   * 73X - Fucking
     - 731 - Fucking Rubygems
-    - 732 - Fucking Unic💩de
+    - 732 - Fucking Unicöde
     - 733 - Fucking Deadlocks
     - 734 - Fucking Deferreds
     - 735 - Fucking IE


### PR DESCRIPTION
Was tempted to change to Üñîçø∂é.
