### PR TITLE
Add 7710 - Used String Prefix Instead of Math error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ We humbly suggest the following status codes are included in the HTTP spec in th
     - 777 - Coincidence
     - 778 - Off By One Error
     - 779 - Off By Too Many To Count Error
+    - 7710 - Used String Prefix Instead of Math
   * 78X - Somebody Else's Problem
     - 780 - Project owner not responding
     - 781 - Operations


### PR DESCRIPTION
Probably would have been more relevant back in 19100.