### PR TITLE
Correction of 78X description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ We humbly suggest the following status codes to be included in the HTTP spec in 
     - 777 - Coincidence
     - 778 - Off By One Error
     - 779 - Off By Too Many To Count Error
-  * 78X - Somebody Else's Problem
+  * 78X - Somebody Else's Fail
     - 780 - Project owner not responding
     - 781 - Operations
     - 782 - QA


### PR DESCRIPTION
From the previous description it isn't clear what the cause of the problem. I think we should use a different description:
Someone Else's Fail/Not Problem Of Mine/Not Mea Culpa