### PR TITLE
740- Fucking Bower

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ We humbly suggest the following status codes to be included in the HTTP spec in 
     - 737 - FuckThreadsing
     - 738 - Fucking Bundler
     - 739 - Fucking Windows
+    - 740 - Fucking Bower
   * 74X - Meme Driven
     - 740 - Computer says no
     - 741 - Compiling


### PR DESCRIPTION
Because someone decided the javascript installer could be a dependancy manager.
