### PR TITLE
For when a 403 Forbidden should be turned into a 404 Not Found

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ We humbly suggest the following status codes to be included in the HTTP spec in 
     - 725 - It works on my machine
     - 726 - It's a feature, not a bug
     - 727 - 32 bits is plenty
+    - 728 - Someone else's content is Not Found
   * 73X - Fucking
     - 730 - Fucking Bower
     - 731 - Fucking Rubygems


### PR DESCRIPTION
Not sure about the wording yet.

And a better code would be `403.5`, but that doesn't fit the 7xx series that well.