### PR TITLE
Add 740 for fucking Python packaging issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ We humbly suggest the following status codes to be included in the HTTP spec in 
     - 737 - FuckThreadsing
     - 738 - Fucking Bundler
     - 739 - Fucking Windows
+    - 740 - Fucking MANIFEST.in
   * 74X - Meme Driven
     - 740 - Computer says no
     - 741 - Compiling


### PR DESCRIPTION
There are a number of long-standing issues with Python packaging, and I chose the MANIFEST.in file (a template needed to include non-Python files like a README into a Python source package) as a particularly egregious case.  This could have been Fucking Python Eggs, Fucking setup.py or any other of a dozen issues; in any case I think a concrete item is better than a generic Fucking Python Packaging label for instace.