### PR TITLE
Swap 418 with 419 because of rfc 2324

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,8 @@ We humbly suggest the following status codes to be included in the HTTP spec in 
     - 710 - PHP
     - 711 - Convenience Store
     - 712 - NoSQL
-    - 718 - Haskell
-    - 719 - I am not a teapot
+    - 718 - I am not a teapot
+    - 719 - Haskell
   * 72X - Edge Cases
     - 720 - Unpossible
     - 721 - Known Unknowns


### PR DESCRIPTION
Since the referenced teapot error code is 418, I suggest making 718 instead of 719 I am not a teapot. See https://www.ietf.org/rfc/rfc2324.txt